### PR TITLE
chore: remove unused uuid dependencies

### DIFF
--- a/.changeset/rare-crabs-throw.md
+++ b/.changeset/rare-crabs-throw.md
@@ -1,0 +1,6 @@
+---
+'@journeyapps-labs/common-utils': patch
+'@journeyapps-labs/common-sdk': patch
+---
+
+Removed unused uuid dependency

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -35,13 +35,11 @@
     "@journeyapps-labs/micro-streaming": "^1.0.2",
     "agentkeepalive": "^4.6.0",
     "bson": "^7.2.0",
-    "lodash": "^4.17.23",
-    "uuid": "^13.0.0"
+    "lodash": "^4.17.23"
   },
   "devDependencies": {
     "vitest": "^4.0.18",
     "@types/lodash": "^4.17.23",
-    "@types/uuid": "^11.0.0",
     "nock": "^14.0.11"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,5 @@
   "license": "Apache-2.0",
   "main": "./dist/index.js",
   "typings": "./dist/@types/index",
-  "dependencies": {
-    "uuid": "^13.0.0"
-  }
+  "dependencies": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,16 +79,10 @@ importers:
       lodash:
         specifier: ^4.17.23
         version: 4.17.23
-      uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
     devDependencies:
       '@types/lodash':
         specifier: ^4.17.23
         version: 4.17.23
-      '@types/uuid':
-        specifier: ^11.0.0
-        version: 11.0.0
       nock:
         specifier: ^14.0.11
         version: 14.0.11
@@ -106,11 +100,7 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.2.3)(jiti@1.21.7)(terser@5.43.1)(yaml@2.8.1)
 
-  packages/utils:
-    dependencies:
-      uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
+  packages/utils: {}
 
 packages:
 
@@ -1988,10 +1978,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@11.0.0':
-    resolution: {integrity: sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==}
-    deprecated: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5523,12 +5509,9 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
-
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   value-equal@1.0.1:
@@ -8545,10 +8528,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/uuid@11.0.0':
-    dependencies:
-      uuid: 13.0.0
 
   '@types/ws@8.18.1':
     dependencies:
@@ -12615,8 +12594,6 @@ snapshots:
   utility-types@3.11.0: {}
 
   utils-merge@1.0.1: {}
-
-  uuid@13.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
In a similar vein to https://github.com/powersync-ja/powersync-service/pull/623, I wanted to bump the `uuid` dependency here, in the `common-sdk` and `common-utils` packages, to v14 in order to silence some pesky warnings in downstream consumers.

The TLDR from the linked PR is:

> The main reason for doing this is to avoid downstream audit warnings for https://github.com/advisories/GHSA-w5hq-g745-h8pq. The fix was backported to v11, but the public advisory metadata lists 14.0.0 as the patched version, so consumers can still see audit failures when installing packages like @powersync/service-sync-rules.

After doing the bump, I noticed that these packages don't seem to actually use the `uuid` library. So, this removes the `uuid` dependency. 

There might be some chance that this is being used to satisfy some transitive dependency - but, I can't see reasons for this in this repo. I'm happy to do any other tests one can recommend. 

